### PR TITLE
Automating expansion of pandas dataframe object types from ROOT TTree

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -5,40 +5,60 @@ import optparse
 from ml import RatioEstimator
 from ml.utils.loading import Loader
 
+#################################################
+# Arugment parsing
 parser = optparse.OptionParser(usage="usage: %prog [opts]", version="%prog 1.0")
-parser.add_option('-s', '--samples',   action='store', type=str, dest='samples',   default='dilepton', help='samples to derive weights for. Sherpa 2.2.8 ttbar dilepton')
-parser.add_option('-v', '--variation', action='store', type=str, dest='variation', default='QSFUP', help='variation to derive weights for. default QSF down to QSF up')
-parser.add_option('-n', '--nentries',  action='store', type=str, dest='nentries',  default=1000, help='specify the number of events do do the training on, default None means full sample')
-parser.add_option('-p', '--datapath',  action='store', type=str, dest='datapath',  default='/eos/atlas/unpledged/group-tokyo/users/tatsuya/TruthAOD/Temp/Tuples/', help='path to where the data is stored')
-
+parser.add_option('-n', '--nominal',   action='store', type=str, dest='nominal',   default='', help='Nominal sample name (root file name excluding the .root extension)')
+parser.add_option('-v', '--variation', action='store', type=str, dest='variation', default='', help='Variation sample name (root file name excluding the .root extension)')
+parser.add_option('-e', '--nentries',  action='store', type=str, dest='nentries',  default=1000, help='specify the number of events to do the training on, None means full sample')
+parser.add_option('-p', '--datapath',  action='store', type=str, dest='datapath',  default='./Inputs/', help='path to where the data is stored')
+parser.add_option('-g', '--global_name',  action='store', type=str, dest='global_name',  default='Test', help='Global name for identifying this run - used in folder naming and output naming')
+parser.add_option('-f', '--features',  action='store', type=str, dest='features',  default='', help='Comma separated list of features within tree')
+parser.add_option('-w', '--weightFeature',  action='store', type=str, dest='weightFeature',  default='', help='Name of event weights feature in TTree')
+parser.add_option('-t', '--TreeName',  action='store', type=str, dest='treename',  default='Tree', help='Name of TTree name inside root files')
 (opts, args) = parser.parse_args()
-sample = opts.samples
-var = opts.variation
+nominal  = opts.nominal
+variation = opts.variation
 n = opts.nentries
 p = opts.datapath
+global_name = opts.global_name
+features = opts.features.split(",")
+weightFeature = opts.weightFeature
+treename = opts.treename
+#################################################
+
+
 logger = logging.getLogger(__name__)
-if os.path.exists('data/'+sample+'/'+var+'/X_train_'+str(n)+'.npy'):
-    logger.info(" Doing evaluation of model trained with datasets: %s , generator variation: %s  with %s  events.", sample, var, n)
+if os.path.exists('data/'+global_name+'/X_train_'+str(n)+'.npy') and os.path.exists('data/'+global_name+'/metaData_'+str(n)+'.pkl'):
+    logger.info(" Doing evaluation of model trained with datasets: [{}, {}], with {} events.".format(nominal, variation, n))
 else:
-    logger.info(" No datasets available for evaluation of model trained with datasets: %s , generator variation: %s  with %s  events.", sample, var, n)
+    logger.info(" No datasets available for evaluation of model trained with datasets: [{},{}] with {} events.".format(nominal, variation, n))
     logger.info("ABORTING")
     sys.exit()
     
 loading = Loader()
 carl = RatioEstimator()
-carl.load('models/'+sample+'/'+var+'_carl_'+str(n))
+carl.load('models/'+global_name+'_carl_'+str(n))
 evaluate = ['train','val']
 for i in evaluate:
-    r_hat, _ = carl.evaluate(x='data/'+sample+'/'+var+'/X0_'+i+'_'+str(n)+'.npy')
+    print("<evaluate.py::__init__>::   Running evaluation for {}".format(i))
+    r_hat, _ = carl.evaluate(x='data/'+global_name+'/X0_'+i+'_'+str(n)+'.npy')
     w = 1./r_hat
-    loading.load_result(x0='data/'+sample+'/'+var+'/X0_'+i+'_'+str(n)+'.npy',     
-                        x1='data/'+sample+'/'+var+'/X1_'+i+'_'+str(n)+'.npy',
+    print("<evaluate.py::__init__>::   Loading Result for {}".format(i))
+    loading.load_result(x0='data/'+global_name+'/X0_'+i+'_'+str(n)+'.npy',     
+                        x1='data/'+global_name+'/X1_'+i+'_'+str(n)+'.npy',
+                        metaData='data/'+global_name+'/metaData_'+str(n)+'.pkl',
                         weights=w, 
+                        features=features,
+                        weightFeature=weightFeature,
                         label=i,
-                        do=sample,
-                        var=var,
                         plot=True,
-                        n=n,
-                        path=p,
-    )
-carl.evaluate_performance(x='data/'+sample+'/'+var+'/X_val_'+str(n)+'.npy',y='data/'+sample+'/'+var+'/y_val_'+str(n)+'.npy')
+                        nentries=n,
+                        TreeName=treename,
+                        pathA=p+nominal+".root",
+                        pathB=p+variation+".root",
+                        global_name=global_name,
+                    )
+# Evaluate performance
+carl.evaluate_performance(x='data/'+global_name+'/X_val_'+str(n)+'.npy',
+                          y='data/'+global_name+'/y_val_'+str(n)+'.npy')

--- a/ml/base.py
+++ b/ml/base.py
@@ -264,7 +264,8 @@ class Estimator(object):
 
     def _transform_inputs(self, x, scaling = "minmax"):
         if scaling == "standard":    
-            print("doing standard")
+            print("<base.py::_transform_inputs()>::   Doing Standard Scaling")
+            #Check for standard deviation = 0 and none values
             if self.x_scaling_means is not None and self.x_scaling_stds is not None:
                 if isinstance(x, torch.Tensor):
                     x_scaled = x - torch.tensor(self.x_scaling_means, dtype=x.dtype, device=x.device)
@@ -275,14 +276,17 @@ class Estimator(object):
             else:
                 x_scaled = x
         else:
-            print("doing min max")
+            print("<base.py::_transform_inputs()>::   Doing min-max scaling")
+            # Check for none and 0 values
             if self.x_scaling_mins is not None and self.x_scaling_maxs is not None:
                 if isinstance(x, torch.Tensor):
                     x_scaled = (x-torch.tensor(self.x_scaling_mins, dtype=x.dtype, device=x.device))
                     x_scaled = x_scaled/(torch.tensor(self.x_scaling_maxs, dtype=x.dtype, device=x.device) - torch.tensor(self.x_scaling_mins, dtype=x.dtype, device=x.device))
                 else:
                     x_scaled = (x - self.x_scaling_mins)
-                    x_scaled = x_scaled/(self.x_scaling_maxs - self.x_scaling_mins)
+                    #x_scaled = x_scaled/(self.x_scaling_maxs - self.x_scaling_mins)
+                    diff = (self.x_scaling_maxs - self.x_scaling_mins)
+                    x_scaled = np.divide(x_scaled, diff, out=np.zeros_like(x_scaled), where=diff!=0) 
             else:
                 x_scaled = x
         return x_scaled

--- a/ml/utils/loading.py
+++ b/ml/utils/loading.py
@@ -14,8 +14,8 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from functools import partial
-
-from .tools import create_missing_folders, load, load_and_check
+from collections import defaultdict
+from .tools import create_missing_folders, load, load_and_check, HarmonisedLoading
 from .plotting import draw_weighted_distributions, draw_unweighted_distributions, draw_ROC, resampled_discriminator_and_roc, plot_calibration_curve, draw_weights, draw_scatter
 from sklearn.model_selection import train_test_split
 logger = logging.getLogger(__name__)
@@ -50,8 +50,7 @@ class Loader():
         Parameters
         ----------
         folder : str or None
-            Path to the folder where the resulting samples should be saved (ndarrays in .npy format). Default value:
-            None.
+            Path to the folder where the resulting samples should be saved (ndarrays in .npy format). Default value:            None.
         plot : bool, optional
             make validation plots
         global_name : str
@@ -79,36 +78,61 @@ class Loader():
             (denominator) hypothesis. The same information is saved as a file in the given folder.
         """
 
+        # Create folders for storage
         create_missing_folders([folder+'/'+global_name])
         create_missing_folders(['plots'])
         
-        ## OLD
-        # load samples
-        #etaJ = [-2.8,-2.4,-2,-1.6,-1.2,-0.8,-0.4,0,0.4,0.8,1.2,1.6,2,2.4,2.8]
-        #eventVars = ['Njets', 'MET']
-        #jetVars   = ['Jet_Pt', 'Jet_Mass']
-        #lepVars   = ['Lepton_Pt']
-        #jetBinning = [range(0, 1500, 50), range(0, 200, 10)]
-        #lepBinning = [range(0, 700, 20)]
-
-        x0, w0, vlabels0 = load(f = pathA, features=features, weightFeature=weightFeature, n = int(nentries), t = TreeName)
-        x1, w1, vlabels1 = load(f = pathB, features=features, weightFeature=weightFeature, n = int(nentries), t = TreeName)
+        # Extract the TTree data as pandas dataframes
+        (
+            x0, w0, vlabels0, 
+            x1, w1, vlabels1
+        )  = HarmonisedLoading(fA = pathA, fB = pathB,
+                               features=features, weightFeature=weightFeature, 
+                               nentries = int(nentries), TreeName = TreeName)
+        
+        # Run if requested debugging by user
+        print("<loading.py::load()>::   Data sets for training (pandas dataframe)")
+        print("<loading.py::load()>::      X0:")
+        print(x0)
+        print("<loading.py::load()>::      X1:")
+        print(x1)
 
         # Pre-process for outliers
         logger.info(" Starting filtering")
         if preprocessing:
-            factor = 5 # 5signma deviation
+            factor = 5 # 5sigma deviation
             x00 = len(x0)
             x10 = len(x1)
             for column in x0.columns:
-                upper_lim = x0[column].mean () + x0[column].std () * factor
-                upper_lim = x1[column].mean () + x1[column].std () * factor
-                lower_lim = x0[column].mean () - x0[column].std () * factor
-                lower_lim = x1[column].mean () - x1[column].std () * factor
+                upper_lim0 = x0[column].mean () + x0[column].std () * factor
+                upper_lim1 = x1[column].mean () + x1[column].std () * factor
+                lower_lim0 = x0[column].mean () - x0[column].std () * factor
+                lower_lim1 = x1[column].mean () - x1[column].std () * factor
+                upper_lim = upper_lim0 if upper_lim0 > upper_lim1 else upper_lim1
+                lower_lim = lower_lim0 if lower_lim0 < lower_lim1 else lower_lim1
+
+                # If the std = 0, then skip as this is a singular value feature 
+                #   Can happen during zero-padding
+                if x0[column].std == 0 or x1[column].std () == 0:
+                    continue
+                
+                #print("Column: {}:".format(column))
+                #print(x0[column])
+                #print(x1[column])
+                print("Column: {},  mean0 = {}".format(column, x0[column].mean ()))
+                print("Column: {},  mean1 = {}".format(column, x1[column].mean ()))
+                print("Column: {},  std0 = {}".format(column, x0[column].std ()))
+                print("Column: {},  std1 = {}".format(column, x1[column].std ()))
+                print("Column: {},  lower limit = {}".format(column,lower_lim))
+                print("Column: {},  upper limit = {}".format(column,upper_lim))
                 x0 = x0[(x0[column] < upper_lim) & (x0[column] > lower_lim)]
                 x1 = x1[(x1[column] < upper_lim) & (x1[column] > lower_lim)]
+                #print(len(x0))
+                #print(len(x1))
             x0 = x0.round(decimals=2)
             x1 = x1.round(decimals=2)
+            print(len(x0))
+            print(len(x1))
             logger.info(" Filtered x0 outliers in percent: %.2f", (x00-len(x0))/len(x0)*100)
             logger.info(" Filtered x1 outliers in percent: %.2f", (x10-len(x1))/len(x1)*100)
         
@@ -124,7 +148,14 @@ class Loader():
         
         if plot and int(nentries) > 10000: # no point in plotting distributions with too few events
             logger.info(" Making plots")
-            draw_unweighted_distributions(x0.to_numpy(), x1.to_numpy(), np.ones(x0.to_numpy()[:,0].size), x0.columns, vlabels, binning, var, do, nentries, plot) 
+            draw_unweighted_distributions(x0.to_numpy(), x1.to_numpy(), 
+                                          np.ones(x0.to_numpy()[:,0].size), 
+                                          x0.columns, 
+                                          vlabels1, 
+                                          binning, 
+                                          global_name, 
+                                          nentries, 
+                                          plot) 
             
         # sort dataframes alphanumerically 
         x0 = x0[sorted(x0.columns)]
@@ -188,15 +219,17 @@ class Loader():
         self,
         x0,
         x1,
+        metaData,
         weights = None,
         label = None,
         features=[],
         weightFeature="",    
-        #do = 'dilepton',
-        #var = 'QSFUP',
         plot = False,
-        n = 0,
+        nentries = 0,
+        TreeName = "Tree",
         pathA = '',
+        pathB = '',
+        global_name="Test"
     ):
         """
         Parameters
@@ -206,27 +239,68 @@ class Loader():
         Returns
         -------
         """
-        eventVars = ['Njets', 'MET']
-        jetVars   = ['Jet_Pt', 'Jet_Mass']
-        lepVars   = ['Lepton_Pt']
-        etaJ = [-2.8,-2.4,-2,-1.6,-1.2,-0.8,-0.4,0,0.4,0.8,1.2,1.6,2,2.4,2.8]
-        jetBinning = [range(0, 1500, 50), range(0, 200, 10)]
-        lepBinning = [range(0, 700, 20)]
+    
+        print("<loading.py::load_result>::   Extracting numpy data features")
 
-        binning = [range(0, 12, 1), range(0, 900, 25)]+jetBinning+jetBinning+lepBinning+lepBinning
-        x0df, labels = load(f = pathA, features=features, weightFeature=weightFeature, n = int(nentries), t = TreeName)
-        #x0df, labels = load(f = path+'/Sh_228_ttbar_'+do+'_EnhMaxHTavrgTopPT_nominal.root', 
-        #                    events = eventVars, jets = jetVars, leps = lepVars, n = 1, t = 'Tree')
-        
+        # Get data - only needed for column names which we can use features instead
+        #x0df, weights0, labels0 = load(f = pathA, 
+        #                     features=features, weightFeature=weightFeature, 
+        #                     n = int(nentries), t = TreeName)
+        #x1df, weights1, labels1 = load(f = pathB, 
+        #                     features=features, weightFeature=weightFeature, 
+        #                     n = int(nentries), t = TreeName)
+                
         # load samples
         X0 = load_and_check(x0, memmap_files_larger_than_gb=1.0)
         X1 = load_and_check(x1, memmap_files_larger_than_gb=1.0)
+        metaDataFile = open(metaData, 'rb')
+        metaDataDict = pickle.load(metaDataFile) 
+        metaDataFile.close()
         weights = weights / weights.sum() * len(X1)
-        if int(n) > 10000: # no point in plotting distributions with too few events, they only look bad 
-            # plot ROC curves     
-            draw_ROC(X0, X1, weights, label, var, do, plot)
-            # plot reweighted distributions     
-            draw_weighted_distributions(X0, X1, weights, x0df.columns, labels, binning, label, var, do, n, plot) 
+
+        # Calculate the maximum of each column and minimum and then allocate bins
+        print("<loading.py::load_result>::   Calculating min/max range for plots & binning")
+        binning = defaultdict()
+        minmax = defaultdict()
+        divisions = 50
+        #for idx,column in enumerate(x0df.columns):
+        for idx,(key,pair) in enumerate(metaDataDict.items()):
+            #max = x0df[column].max()
+            #min = x0df[column].min()
+            #minmax[column] = [min,max]
+            #binning[column] = np.linspace(min, max, divisions)
+            #print("<loading.py::load_result>::   Column {}:  min  =  {},  max  =  {}".format(column,min,max))
+
+            #  Min/max
+            #max = np.amax(X0[:,idx])
+            #min = np.amin(X0[:,idx])
+            #minmax[idx] = [min,max]
+            #binning[idx] = np.linspace(min, max, divisions)
+            #print("<loading.py::load_result>::   Column {}:  min  =  {},  max  =  {}".format(column,min,max))
+
+            #  Mean/std
+            mean = np.mean(X0[:,idx])
+            std = np.std(X0[:,idx])
+            factor = 5
+            minmax[idx] = [mean-(5*std), mean+(5*std)]
+            binning[idx] = np.linspace(mean-(5*std), mean+(5*std), divisions)
+            print("<loading.py::load_result>::   Column {}:  min  =  {},  max  =  {}".format(key,mean,std))
+            print(binning[idx])
+
+        # no point in plotting distributions with too few events, they only look bad 
+        #if int(nentries) > 5000: 
+        # plot ROC curves 
+        print("<loading.py::load_result>::   Printing ROC")
+        draw_ROC(X0, X1, weights, label, global_name, nentries, plot)
+        
+        print("<loading.py::load_result>::   Printing weighted distributions")
+        # plot reweighted distributions     
+        draw_weighted_distributions(X0, X1, 
+                                    weights, 
+                                    metaDataDict.keys(),#x0df.columns, 
+                                    binning, 
+                                    label, 
+                                    global_name, nentries, plot) 
 
     def validate_result(
         self,

--- a/ml/utils/plotting.py
+++ b/ml/utils/plotting.py
@@ -21,7 +21,14 @@ logger = logging.getLogger(__name__)
 hist_settings0 = {'alpha': 0.3}
 hist_settings1 = {'histtype':'step', 'color':'black', 'linewidth':1, 'linestyle':'--'}
 
-def draw_unweighted_distributions(x0, x1, weights, variables, vlabels, binning, legend, do, n, save = False):
+def draw_unweighted_distributions(x0, x1, 
+                                  weights, 
+                                  variables,
+                                  vlabels, 
+                                  binning, 
+                                  legend, 
+                                  n, 
+                                  save = False):
     plt.figure(figsize=(14, 10))
     columns = range(len(variables))
     for id, column in enumerate(columns, 1):
@@ -30,33 +37,46 @@ def draw_unweighted_distributions(x0, x1, weights, variables, vlabels, binning, 
         plt.yscale('log')
         plt.hist(x0[:,column], bins = binning[id-1], weights=weights, label = "nominal", **hist_settings0)
         plt.hist(x1[:,column], bins = binning[id-1], label = legend, **hist_settings1)
-        plt.xlabel('ttbar %s, %s'%(do, vlabels[id-1]), horizontalalignment='right',x=1) 
+        plt.xlabel('%s'%(vlabels[id-1]), horizontalalignment='right',x=1) 
         plt.legend(frameon=False)
         axes = plt.gca()
         axes.set_ylim([len(x0)*0.001,len(x0)*2])                  
         if save:
             create_missing_folders(["plots"])                                                              
-            plt.savefig("plots/%s_%s_nominalVs%s_%s.png"%(variables[id-1], do, legend, n))                                                                
+            plt.savefig("plots/%s_nominalVs%s_%s.png"%(variables[id-1],legend, n))                                                                
             plt.clf()
             plt.close()
 
-def draw_weighted_distributions(x0, x1, weights, variables, vlabels, binning, label, legend, do, n, save = False):
+def draw_weighted_distributions(x0, x1, 
+                                weights, 
+                                variables, 
+                                binning, label, 
+                                legend, 
+                                n, 
+                                save = False):
     plt.figure(figsize=(14, 10))
-    columns = range(len(variables))
-    for id, column in enumerate(columns, 1):
+    #columns = range(len(variables))
+
+    for id, column in enumerate(variables):
+        print("<plotting.py::draw_weighted_distribution()>::   id: {},   column: {}".format(id,column))
+        print("<plotting.py::draw_weighted_distribution()>::     binning: {}".format(binning[id]))
         if save: plt.figure(figsize=(5, 4)) 
         else: plt.subplot(3,4, id)
         plt.yscale('log')
-        plt.hist(x0[:,column], bins = binning[id-1], label = "nominal", **hist_settings0)
-        plt.hist(x0[:,column], bins = binning[id-1], weights=weights, label = 'nominal*CARL', **hist_settings0)
-        plt.hist(x1[:,column], bins = binning[id-1], label = legend, **hist_settings1)
-        plt.xlabel('ttbar %s, %s'%(do, vlabels[id-1]), horizontalalignment='right',x=1) 
+        #plt.hist(x0[:,id], bins = binning[column], label = "nominal", **hist_settings0)
+        #plt.hist(x0[:,id], bins = binning[column], weights=weights, label = 'nominal*CARL', **hist_settings0)
+        #plt.hist(x1[:,id], bins = binning[column], label = legend, **hist_settings1)
+
+        plt.hist(x0[:,id], bins = binning[id], label = "nominal", **hist_settings0)
+        plt.hist(x0[:,id], bins = binning[id], weights=weights, label = 'nominal*CARL', **hist_settings0)
+        plt.hist(x1[:,id], bins = binning[id], label = legend, **hist_settings1)
+        plt.xlabel('%s'%(column), horizontalalignment='right',x=1) 
         plt.legend(frameon=False,title = '%s sample'%(label) )
         axes = plt.gca()
         axes.set_ylim([len(x0)*0.001,len(x0)*2])                 
         if save:
             create_missing_folders(["plots"])                                                              
-            plt.savefig("plots/w_%s_%s_nominalVs%s_%s_%s.png"%(variables[id-1], do, legend,label, n)) 
+            plt.savefig("plots/w_%s_nominalVs%s_%s_%s.png"%(column, legend,label, n)) 
             plt.clf()
             plt.close()
 
@@ -90,7 +110,7 @@ def resampled_discriminator_and_roc(original, target, weights):
     roc_auc = auc(fpr, tpr)
     return fpr,tpr,roc_auc
  
-def draw_ROC(X0, X1, weights, label, legend, do, n, plot = True):
+def draw_ROC(X0, X1, weights, label, legend, n, plot = True):
     plt.figure(figsize=(4, 3))
     no_weights_scaled = np.ones(X0.shape[0])/np.ones(X0.shape[0]).sum() * len(X1)
     fpr_t,tpr_t,roc_auc_t = resampled_discriminator_and_roc(X0, X1, no_weights_scaled)
@@ -106,7 +126,7 @@ def draw_ROC(X0, X1, weights, label, legend, do, n, plot = True):
     plt.legend(loc="lower right", title = label)
     plt.tight_layout()
     if plot:
-        plt.savefig('plots/roc_nominalVs%s_%s_%s_%s.png'%(legend,do,label, n)) 
+        plt.savefig('plots/roc_nominalVs%s_%s_%s.png'%(legend,label, n)) 
         plt.clf()    
     logger.info("CARL weighted %s AUC is %.3f"%(label,roc_auc_tC))
     logger.info("Unweighted %s AUC is %.3f"%(label,roc_auc_t))

--- a/ml/utils/tools.py
+++ b/ml/utils/tools.py
@@ -9,12 +9,96 @@ import uproot
 import pandas as pd
 import torch
 from torch.nn import functional as F
-
+from collections import defaultdict
 from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
 initialized = False
+
+def HarmonisedLoading(fA="",
+                      fB="",
+                      features=[],
+                      weightFeature="",
+                      nentries=0,
+                      TreeName="Tree"        
+                  ):
+    
+
+    x0, w0, vlabels0 = load(f = fA, 
+                            features=features, weightFeature=weightFeature, 
+                            n = int(nentries), t = TreeName)
+    x1, w1, vlabels1 = load(f = fB, 
+                            features=features, weightFeature=weightFeature,
+                            n = int(nentries), t = TreeName)
+    
+    x0, x1 = CoherentFlattening(x0,x1)
+
+    return x0, w0, vlabels0, x1, w1, vlabels1
+    
+
+    
+def CoherentFlattening(df0, df1):
+    
+    # Find the lowest common denominator for object lengths
+    df0_objects = df0.select_dtypes(object)
+    df1_objects = df1.select_dtypes(object)
+    minObjectLen = defaultdict()
+    for column in df0_objects:
+        elemLen0 = df0[column].apply(lambda x: len(x)).max() 
+        elemLen1 = df1[column].apply(lambda x: len(x)).max() 
+        
+        minObjectLen[column] = elemLen0 if elemLen0 < elemLen1 else elemLen1
+        print("<tools.py::CoherentFlattening()>::   Variable: {}({}),   min size = {}".format( column, df0[column].dtypes, minObjectLen))
+        print("<tools.py::CoherentFlattening()>::      Element Length 0 = {}".format( elemLen0))
+        print("<tools.py::CoherentFlattening()>::      Element Length 1 = {}".format( elemLen1))
+        
+    # Warn user
+    if elemLen0 != elemLen1:
+        print("<tools.py::CoherentFlattening()>::   The two datasets do not have the same length for features '{}', please be warned that we choose zero-padding using lowest dimensionatlity".format(column))
+        
+    # Find the columns that are not scalars and get all object type columns
+    #maxListLength = df.select_dtypes(object).apply(lambda x: x.list.len()).max(axis=1)
+    for column in df0_objects:
+        elemLen0 = df0[column].apply(lambda x: len(x)).max() 
+        elemLen1 = df1[column].apply(lambda x: len(x)).max() 
+
+
+        # Now break up each column into elements of max size 'macObjectLen'
+        df0_flattened = pd.DataFrame(df0[column].to_list(), columns=[column+str(idx) for idx in range(elemLen0)])
+        df0_flattened = df0_flattened.fillna(0)
+        
+        # Delete extra dimensions if needed due to non-matching dimensionality of df0 & df1
+        if elemLen0 > minObjectLen[column]:
+            delColumns0 = [column+str(idx) for idx in range(minObjectLen[column], elemLen0)]
+            print("<tools.py::CoherentFlattening()>::   Deleting {}".format(delColumns0))
+            for idx in range(minObjectLen[column], elemLen0):
+                del df0_flattened[column+str(idx)]
+
+        #print(df[column])
+        #print(df_flattened)
+        del df0[column]
+        df0 = df0.join(df0_flattened)
+
+        # Now break up each column into elements of max size 'macObjectLen'
+        df1_flattened = pd.DataFrame(df1[column].to_list(), columns=[column+str(idx) for idx in range(elemLen1)])
+        df1_flattened = df1_flattened.fillna(0)
+
+        # Delete extra dimensions if needed due to non-matching dimensionality of df0 & df1
+        if elemLen1 > minObjectLen[column]:
+            delColumns1 = [column+str(idx) for idx in range(minObjectLen[column], elemLen1)]
+            print("<tools.py::CoherentFlattening()>::   Deleting {}".format(delColumns1))
+            for idx in range(minObjectLen[column], elemLen1):
+                del df1_flattened[column+str(idx) ]
+
+        #print(df[column])
+        #print(df_flattened)
+        del df1[column]
+        df1 = df1.join(df1_flattened)
+
+    print("<loading.py::load()>::    Flattened Dataframe")
+    #print(df)
+    return df0,df1
 
 def load(
     f="",
@@ -40,88 +124,17 @@ def load(
         
     # Extract the pandas dataframe - warning about jagged arrays
     df = X_tree.pandas.df(features, flatten=False)
-    print(df)
-
-    # Find the columns that are none scalarsand get all object type columns
-    #maxListLength = df.select_dtypes(object).apply(lambda x: x.list.len()).max(axis=1)
-    df_objects = df.select_dtypes(object)
-    maxObjectLen = -1
-    for column in df_objects:
-        elemLen = df[column].apply(lambda x: len(x)).max() 
-        print("Variable: {}({}),   max size = {}", column, df[column].dtypes, elemLen)
-        # Now break up each column into elements of max size 'macObjectLen'
-        df_flattened = pd.DataFrame(df[column].to_list(), columns=[column+str(idx) for idx in range(elemLen)])
-        df_flattened = df_flattened.fillna(0)
-        print("Flattened Columns:")
-        print(df_flattened)
-        maxObjectLen = elemLen if elemLen > maxObjectLen else maxObjectLen
-    print("Max list length:", maxObjectLen)
-
-
 
     # Extract the weights from the Tree if specificed 
     if weightFeature == "":
         weights = len(df.index)
     else:
         weights = X_tree[weightFeature]
-
         
     # For the moment one should siply use the features
     labels  = features
 
     return (df, weights, labels)
-
-
-#def load(f = None, events = None, jets = None, leps = None, n = 0, t = None, do = "dilepton"):
-#    if f is None:
-#        return None
-#    tree = uproot.open(f)[t]
-#    if int(n) > 0: # if n > 0 n is the number of entries to do training on 
-#        df    = tree.pandas.df(events, entrystop = int(n))
-#        jetdf = tree.pandas.df(jets, entrystop = int(n))
-#        lepdf = tree.pandas.df(leps, entrystop = int(n))
-#    else: # else do training on the full sample
-#        df    = tree.pandas.df(events)
-#        jetdf = tree.pandas.df(jets)
-#        lepdf = tree.pandas.df(leps)
-#    if do == "dilepton":
-#        nJet = 2; nLep = 2
-#        dfj1 = jetdf.xs(0, level='subentry')
-#        dfj2 = jetdf.xs(1, level='subentry')
-#        dfl1 = lepdf.xs(0, level='subentry')
-#        dfl2 = lepdf.xs(1, level='subentry')
-#        final = df.assign(Jet1_Pt = dfj1['Jet_Pt'], Jet1_Mass=dfj1['Jet_Mass'], 
-#                          Jet2_Pt = dfj2['Jet_Pt'], Jet2_Mass=dfj2['Jet_Mass'], 
-#                          Lep1_Pt = dfl1['Lepton_Pt'],
-#                          Lep2_Pt = dfl2['Lepton_Pt']).fillna(0.0)   
-#    if do == "SingleLepP" or do == "SingleLepM":
-#        nJet = 3; nLep = 1
-#        dfj1 = jetdf.xs(0, level='subentry')
-#        dfj2 = jetdf.xs(1, level='subentry')
-#        dfj3 = jetdf.xs(2, level='subentry')
-#        dfl1 = lepdf.xs(0, level='subentry')
-#        final = df.assign(Jet1_Pt = dfj1['Jet_Pt'], Jet1_Mass=dfj1['Jet_Mass'], 
-#                          Jet2_Pt = dfj2['Jet_Pt'], Jet2_Mass=dfj2['Jet_Mass'],     
-#                          Jet3_Pt = dfj3['Jet_Pt'], Jet3_Mass=dfj3['Jet_Mass'],     
-#                          Lep1_Pt = dfl1['Lepton_Pt']).fillna(0.0)            
-#    if do == "AllHadronic":
-#        nJet = 4; nLep = 0
-#        dfj1 = jetdf.xs(0, level='subentry')
-#        dfj2 = jetdf.xs(1, level='subentry')
-#        dfj3 = jetdf.xs(2, level='subentry')
-#        dfj4 = jetdf.xs(3, level='subentry')
-#        final = df.assign(Jet1_Pt = dfj1['Jet_Pt'], Jet1_Mass=dfj1['Jet_Mass'], 
-#                          Jet2_Pt = dfj2['Jet_Pt'], Jet2_Mass=dfj2['Jet_Mass'],   
-#                          Jet3_Pt = dfj3['Jet_Pt'], Jet3_Mass=dfj3['Jet_Mass'],   
-#                          Jet4_Pt = dfj4['Jet_Pt'], Jet4_Mass=dfj4['Jet_Mass']).fillna(0.0)          
-#    labels =  ['Number of jets', '$\mathrm{p_{T}^{miss}}$ [GeV]']
-#    for j in range(1, nJet+1):
-#        labels.append('Jet '+str(j)+' $\mathrm{p_{T}}$ [GeV]')
-#        labels.append('Jet '+str(j)+' mass [GeV]')
-#    for l in range(1, nLep+1):
-#        labels.append('Lepton '+str(j)+' $\mathrm{p_{T}}$ [GeV]')
-#
-#    return final, labels
 
 
 def create_missing_folders(folders):


### PR DESCRIPTION
# Purpose

Conversion of ROOT TTree style flat tuples into `pandas` data frame using `uproot` is non-trivial when  a `TBranch` with a `std::vector` type data type exists, because the vector has a dynamic size. Consequently, `uproot.pandas.df(flatten=True)` option does not work, and `flatten=False` yields nested data frame structures

## Solution

The following pull request introduces dynamic flattening of `type(TBranch *) == object` by appending columns to pre-existing dataframe.
